### PR TITLE
Use prehashing by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ If no signature file is specified, the signature file must be in the same direct
  -V                verify that a signature is valid for a given file
  -m <file>         file to sign/verify
  -o                combined with -V, output the file content after verification
- -H                combined with -S, pre-hash in order to sign large files
  -p <pubkeyfile>   public key file (default: ./minisign.pub)
  -P <pubkey>       public key, as a base64 string
  -s <seckey>       secret key file (default: ~/.minisign/minisign.key)

--- a/bin/minisign
+++ b/bin/minisign
@@ -14,7 +14,7 @@ var Writable = require('stream').Writable
 // import arguments from command line
 var args = minimist(process.argv.slice(2), {
   string: ['m', 'x', 's', 'p', 'P', 'c', 't', 'k'],
-  boolean: ['G', 'V', 'S', 'F', 'H', 'f', 'q', 'o', 'Q', 'help', 'version', 'secure'],
+  boolean: ['G', 'V', 'S', 'f', 'q', 'o', 'Q', 'help', 'version', 'secure'],
   alias: { h: 'help', v: 'version', x: 'secure' },
   unknown: function () {
     console.log('unrecognised command.')
@@ -36,8 +36,8 @@ mutableStdout.muted = true
 
 const usage = `
   Usage:
-  $ minisign -G [-F] [-p pubkey file] [-s seckey file] [-c pubkey comment] [-t seckey comment]
-  $ minisign -S [-H] [-s seckey file] [-x signature file] [-c comment] [-t trusted comment] -m file
+  $ minisign -G [-f] [-p pubkey file] [-s seckey file] [-c pubkey comment] [-t seckey comment]
+  $ minisign -S [-s seckey file] [-x signature file] [-c comment] [-t trusted comment] -m file
   $ minisign -V [-x signature file] [-p pubkey file | -P public key] [-o] [-q] -m file
 
   -G                generate a new key pair
@@ -45,7 +45,6 @@ const usage = `
   -V                verify that a signature is valid for a given file
   -m <file>         file to sign/verify
   -o                combined with -V, output the file content after verification
-  -H                combined with -S, pre-hash in order to sign large files
   -p <pubkeyfile>   public key file (default: ./minisign.pub)
   -P <pubkey>       public key, as a base64 string
   -s <seckey>       secret key file (default: ~/.minisign/minisign.key)
@@ -113,12 +112,12 @@ function generate (opts, pwd) {
 
   fs.writeFile(opts.PKfile, keys.PK.toString(), opts.overwrite, (err) => {
     if (err && err.code === 'EEXIST') {
-      console.log('keys already exist, use -F tag to force overwrite')
+      console.log('keys already exist, use -f tag to force overwrite')
       process.exit(1)
     }
     fs.writeFile(opts.SKfile, keys.SK.toString(), opts.overwrite, (err) => {
       if (err && err.code === 'EEXIST') {
-        console.log('keys already exist, use -F tag to force overwrite')
+        console.log('keys already exist, use -f tag to force overwrite')
         process.exit(1)
       }
     })
@@ -244,9 +243,6 @@ if (args.S) {
   opts.comment = args.c
   opts.tComment = args.t
 
-  if (args.H) {
-    opts.sigAlgorithm = 'ED'
-  }
   if (args.secure) {
     passwordBuf = sodium.sodium_malloc(4096)
     secureRead(passwordBuf, opts, sign)

--- a/minisign.js
+++ b/minisign.js
@@ -159,7 +159,7 @@ function signContent (content, SKdetails, opts) {
   if (opts == null) opts = {}
   var comment = opts.comment || defaultComment
   var tComment = opts.tComment || (Math.floor(Date.now() / 1000)).toString('10')
-  var sigAlgorithm = Buffer.from(opts.sigAlgorithm || 'Ed')
+  var sigAlgorithm = Buffer.from(opts.sigAlgorithm || 'ED')
   var contentToSign
   var signatureAlgorithm
   var trustComment

--- a/test/parse-signature.js
+++ b/test/parse-signature.js
@@ -129,7 +129,7 @@ test('signContent generated input', (t) => {
     var sigInfo = minisign.parseSignature(signedOutput)
 
     t.equal(sigInfo.signature.length, sodium.crypto_sign_BYTES)
-    t.deepEqual(sigInfo.signatureAlgorithm, Buffer.from('Ed'))
+    t.deepEqual(sigInfo.signatureAlgorithm, Buffer.from('ED'))
     t.equal(sigInfo.keyID.byteLength, 8)
     t.equal(sigInfo.globalSignature.length, sodium.crypto_sign_BYTES)
     t.end()

--- a/test/sign-content.js
+++ b/test/sign-content.js
@@ -3,7 +3,7 @@ var minisign = require('../minisign.js')
 var sodium = require('sodium-native')
 var fs = require('fs')
 
-test('sign empty content with minisign key, no tComment given', (t) => {
+test('sign empty content with minisign key, no comment given', (t) => {
   var comment = 'untrusted comment: signature from minisign secret key'
   var noContent = Buffer.alloc(0)
 
@@ -145,7 +145,9 @@ test('sign with large, emoji comment / tComment', (t) => {
         t.error(err)
         var PKinfo = minisign.parsePubKey(PK)
         t.ok(minisign.verifySignature(parsedOutput1, contentToSign, PKinfo))
-        t.ok(sodium.crypto_sign_verify_detached(parsedOutput2.signature, contentToSign, PKinfo.publicKey))
+        var hashedContent = Buffer.alloc(sodium.crypto_generichash_BYTES_MAX)
+        sodium.crypto_generichash(hashedContent, contentToSign)
+        t.ok(sodium.crypto_sign_verify_detached(parsedOutput2.signature, hashedContent, PKinfo.publicKey))
         t.ok(minisign.verifySignature(parsedOutput2, contentToSign, PKinfo))
         t.end()
       })


### PR DESCRIPTION
Support for non-prehashed signatures are going to eventually be removed. 

Other implementations have been updated to use prehashing by default, so this is a simple PR to do the same here :)